### PR TITLE
Fail-closed CI: не приховувати падіння Playwright

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -29,7 +29,7 @@ jobs:
           bundler-cache: true
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload browser diagnostics on failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-diagnostics-${{ github.run_id }}
           path: artifacts/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Спершу прочитай `CONTEXT.md`; перед роботою з Issue — `docs/agents/issue-tracker.md` і `docs/agents/triage-labels.md`; перед зміною архітектури — релевантні ADR у `docs/adr/`.
 - Веди роботу через GitHub Issue → гілка → PR після bootstrap. Не переписуй історію: без force-push. Незалежний reviewer має схвалити кожен PR до злиття.
 - Незакріплені зміни інших людей не чіпай. Перевірки й команди виводь із поточних файлів проєкту, а не з цього документа.
+- Quality gate працює fail-closed: перший failed або flaky тест робить build червоним; Playwright retries завжди `0`.
 
 ## Agent skills
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help install install-ruby install-node install-browser build serve test test-unit test-browser verify-skills validate html check clean
+.PHONY: help install install-ruby install-node install-browser build serve test test-unit test-browser verify-skills validate validate-quality-policy html check clean
 
 help: ## Показати доступні команди
 	@awk 'BEGIN {FS = ":.*## "; printf "Smart Electrics\n\n"} /^[a-zA-Z_-]+:.*## / {printf "  %-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -37,10 +37,13 @@ verify-skills: ## Перевірити склад і контрольні сум
 validate: ## Перевірити, що зовнішні інтеграції безпечно вимкнені або повністю налаштовані
 	bundle exec ruby scripts/validate_integrations.rb
 
+validate-quality-policy: ## Перевірити fail-closed налаштування тестів
+	npm run validate:quality-policy
+
 html: build ## Перевірити згенерований HTML і внутрішні посилання
 	bundle exec htmlproofer ./_site --disable-external --no-enforce-https
 
-check: verify-skills test-unit html test-browser ## Повний локальний quality gate
+check: verify-skills test-unit validate-quality-policy html test-browser ## Повний локальний quality gate
 
 clean: ## Прибрати лише згенеровані артефакти Jekyll
 	bundle exec jekyll clean

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "playwright test",
     "test:browser": "playwright test",
     "test:browser:headed": "playwright test --headed",
-    "test:browser:update": "playwright test --update-snapshots"
+    "test:browser:update": "playwright test --update-snapshots",
+    "validate:quality-policy": "node scripts/validate_quality_policy.js"
   },
   "engines": {
     "node": "24.x",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -31,7 +31,7 @@ export default defineConfig({
     { name: "desktop-1980", use: { viewport: { width: 1980, height: 1200 } } }
   ],
   webServer: {
-    command: "bundle exec jekyll serve --host 127.0.0.1 --port 4000 --trace",
+    command: "bundle exec jekyll serve --no-watch --host 127.0.0.1 --port 4000 --trace",
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -7,7 +7,8 @@ export default defineConfig({
   outputDir: "artifacts/playwright-results",
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
-  retries: process.env.CI ? 1 : 0,
+  // A failed attempt is a failed quality gate; flakes must remain visible.
+  retries: 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: [
     ["list"],

--- a/scripts/validate_quality_policy.js
+++ b/scripts/validate_quality_policy.js
@@ -33,6 +33,18 @@ for (const scriptName of ["test", "test:browser"]) {
   }
 }
 
+const webServerCommands = Array.isArray(playwrightConfig.webServer)
+  ? playwrightConfig.webServer.map(({ command }) => command)
+  : [playwrightConfig.webServer?.command];
+
+for (const command of webServerCommands) {
+  if (typeof command !== "string" || !command.includes("--no-watch")) {
+    failures.push(
+      "Playwright Jekyll servers must use --no-watch so test artifacts cannot trigger partial rebuilds."
+    );
+  }
+}
+
 if (failures.length > 0) {
   for (const failure of failures) {
     console.error(failure);

--- a/scripts/validate_quality_policy.js
+++ b/scripts/validate_quality_policy.js
@@ -1,11 +1,36 @@
+import { readFileSync } from "node:fs";
 import playwrightConfig from "../playwright.config.js";
 
 const failures = [];
+const packageJson = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8")
+);
 
 if (playwrightConfig.retries !== 0) {
   failures.push(
     `Playwright retries must be 0 so every failed test makes the quality gate fail (received ${playwrightConfig.retries}).`
   );
+}
+
+for (const project of playwrightConfig.projects ?? []) {
+  const effectiveRetries = project.retries ?? playwrightConfig.retries;
+
+  if (effectiveRetries !== 0) {
+    failures.push(
+      `Playwright project ${project.name ?? "<unnamed>"} must use 0 retries (received ${effectiveRetries}).`
+    );
+  }
+}
+
+for (const scriptName of ["test", "test:browser"]) {
+  const command = packageJson.scripts?.[scriptName] ?? "";
+  const retryOverride = command.match(/--retries(?:=|\s+)(\d+)/u);
+
+  if (retryOverride && Number(retryOverride[1]) !== 0) {
+    failures.push(
+      `npm script ${scriptName} overrides Playwright with ${retryOverride[1]} retries.`
+    );
+  }
 }
 
 if (failures.length > 0) {

--- a/scripts/validate_quality_policy.js
+++ b/scripts/validate_quality_policy.js
@@ -1,0 +1,18 @@
+import playwrightConfig from "../playwright.config.js";
+
+const failures = [];
+
+if (playwrightConfig.retries !== 0) {
+  failures.push(
+    `Playwright retries must be 0 so every failed test makes the quality gate fail (received ${playwrightConfig.retries}).`
+  );
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) {
+    console.error(failure);
+  }
+  process.exitCode = 1;
+} else {
+  console.log("Quality policy is fail-closed.");
+}

--- a/tests/browser/site.spec.js
+++ b/tests/browser/site.spec.js
@@ -175,7 +175,12 @@ test("analytics and lead submission remain disabled until their activation gate 
 
 test("key surfaces have no automatically detectable accessibility violations", async ({ page }) => {
   for (const route of ["/", "/services/electrical-installation/", "/privacy/"]) {
-    await page.goto(route);
+    const response = await page.goto(route);
+    expect(response?.ok(), `${route} should return a successful response before axe`).toBeTruthy();
+    await expect(page.locator("main"), `${route} should render its main landmark before axe`).toBeVisible();
+    await expect(page, `${route} should render the Smart Electrics document before axe`).toHaveTitle(
+      /Smart Electrics/
+    );
     const results = await new AxeBuilder({ page }).analyze();
     expect(results.violations, `${route} should pass axe`).toEqual([]);
   }


### PR DESCRIPTION
## Пов’язаний Issue

Closes #10

## Результат для користувача

Quality gate більше не перетворює падіння browser-тесту на зелений build через retry. Кожен failed test одразу робить job червоним. Усунено підтверджену Jekyll/WEBrick race: test server більше не перебудовує site під час Playwright run. Quality actions переведено на підтверджений Node 24 runtime.

## Root cause

Remote trace показав WEBrick 200 OK із Content-Length: 0 саме під час Jekyll auto-regeneration. Stress-loop відтворив 1 порожню відповідь на 21 107 запитів із watch; з --no-watch — 0 порожніх на 37 436 запитів і 0 request errors.

## Acceptance criteria

- [x] Playwright retries дорівнює 0 локально та в CI.
- [x] Машинний guard перевіряє global/project/script retries.
- [x] Playwright Jekyll server використовує --no-watch; guard захищає інваріант.
- [x] Accessibility-тест перевіряє response, main і title до axe.
- [x] Fail-closed правило зафіксовано в AGENTS.md.
- [x] setup-node v7.0.0 та upload-artifact v7.0.1 pinned by SHA; обидва використовують Node 24 runtime.
- [x] Повний CI-mode make check: 51 passed, 4 очікувано skipped за project scope, 0 failed/flaky.

## Незалежний review

- Standards: 0 findings.
- Spec: 0 remaining findings.

Force-push не використовувався.