### PR TITLE
fix: keep compact physical controls readable (#33)

### DIFF
--- a/_sass/_cinematic.scss
+++ b/_sass/_cinematic.scss
@@ -815,6 +815,23 @@
     font-size: 0.68rem;
     padding-inline: 0.45rem;
   }
+
+  .residence-spine__physical-controls fieldset:last-child > div {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .residence-spine__physical-controls fieldset:last-child button:nth-child(-n + 3) {
+    grid-column: span 2;
+  }
+
+  .residence-spine__physical-controls fieldset:last-child button:nth-child(n + 4) {
+    grid-column: span 3;
+  }
+
+  .residence-spine__physical-controls button {
+    overflow-wrap: normal;
+    word-break: normal;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/tests/browser/responsive_matrix.spec.js
+++ b/tests/browser/responsive_matrix.spec.js
@@ -67,25 +67,29 @@ test("composition scales fluidly at intermediate widths", async ({ page }) => {
   }
 });
 
-test("tablet residence controls keep every word intact", async ({ page }) => {
-  await page.setViewportSize({ width: 768, height: 1000 });
-  await page.goto("/services/");
+test("compact residence controls keep every word intact", async ({ page }) => {
+  for (const width of [375, 768]) {
+    await page.setViewportSize({ width, height: width === 375 ? 812 : 1000 });
+    for (const route of ["/", "/services/"]) {
+      await page.goto(route);
 
-  const splitWords = await page
-    .locator("[data-cinematic-physical-controls]:visible button")
-    .evaluateAll((buttons) => buttons.flatMap((button) => {
-      const node = button.firstChild;
-      if (!(node instanceof Text)) return [button.textContent.trim()];
+      const splitWords = await page
+        .locator("[data-cinematic-physical-controls]:visible button")
+        .evaluateAll((buttons) => buttons.flatMap((button) => {
+          const node = button.firstChild;
+          if (!(node instanceof Text)) return [button.textContent.trim()];
 
-      return [...node.data.matchAll(/\S+/gu)].flatMap((match) => {
-        const range = document.createRange();
-        range.setStart(node, match.index);
-        range.setEnd(node, match.index + match[0].length);
-        return range.getClientRects().length > 1 ? [match[0]] : [];
-      });
-    }));
+          return [...node.data.matchAll(/\S+/gu)].flatMap((match) => {
+            const range = document.createRange();
+            range.setStart(node, match.index);
+            range.setEnd(node, match.index + match[0].length);
+            return range.getClientRects().length > 1 ? [match[0]] : [];
+          });
+        }));
 
-  expect(splitWords, "physical-control labels should wrap only between words").toEqual([]);
+      expect(splitWords, `${route} at ${width}px should wrap labels only between words`).toEqual([]);
+    }
+  }
 });
 
 test("smart-home disassembly never expands the document", async ({ page }) => {


### PR DESCRIPTION
## Що змінено

- перебудовано лише мобільну сітку сонцезахисту у композицію 3+2 на ширинах до 576 px
- заборонено перенесення всередині слів у фізичних контролах
- розширено regression на 375 і 768 px для головної та сторінки послуг

## Перевірка

- CI=1 make check: 340 browser tests passed; Ruby/JS unit, validators, production build і HTML-Proofer passed
- окрема browser-матриця: 95/95 passed без retries/skips
- незалежні code/spec та visual/evidence review exact SHA: PASS, без blocker/high/medium findings

Refs #33