### PR TITLE
ci: disable automatic GitHub Quality

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,9 +1,7 @@
 name: Deploy GitHub Pages
 
 on:
-  workflow_run:
-    workflows: [Quality]
-    types: [completed]
+  push:
     branches: [main]
 
 concurrency:
@@ -13,22 +11,16 @@ concurrency:
 jobs:
   build:
     name: build-pages
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.head_repository.full_name == github.repository &&
-      github.event.workflow_run.head_sha != ''
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
 
     steps:
-      - name: Check out verified source
+      - name: Check out pushed source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.sha }}
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,9 +1,8 @@
 name: Quality
 
 on:
-  push:
-    branches: [main]
-  pull_request:
+  # Owner opt-in only; local make check remains the acceptance gate.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - Спершу прочитай `CONTEXT.md`; перед роботою з Issue — `docs/agents/issue-tracker.md` і `docs/agents/triage-labels.md`; перед зміною архітектури — релевантні ADR у `docs/adr/`.
 - Веди роботу через GitHub Issue → гілка → PR після bootstrap. Не переписуй історію: без force-push. Ручний review або approval власника не потрібен; перед злиттям PR виконай автономний merge gate з `docs/agents/workflow.md`.
 - Незакріплені зміни інших людей не чіпай. Перевірки й команди виводь із поточних файлів проєкту, а не з цього документа.
-- Quality gate працює fail-closed: перший failed або flaky тест робить build червоним; Playwright retries завжди `0`.
+- Перед handoff або PR прочитай `docs/agents/workflow.md`: він визначає локальний acceptance, режим GitHub workflows і merge gate. Playwright retries завжди `0`.
 
 ## Agent skills
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ Measurement ID і та сама фінальна політика. `make validat
 ## Робочий процес
 
 Bootstrap є єдиним прямим комітом у `main`. Подальші зміни проходять GitHub
-Issue → гілка → PR → незалежний review → required check `quality`. Почніть з
-`AGENTS.md`, а деталі знайдіть у `docs/agents/`.
+Issue → гілка → PR → незалежний review. Режим локального acceptance, GitHub
+workflows і merge gate визначає `docs/agents/workflow.md`; почніть з
+`AGENTS.md`.
 
 Project-local skills, точні upstream revisions і процедура оновлення описані в
 `.agents/README.md`. Ліцензії сторонніх skills наведені в

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -31,12 +31,18 @@ Codex автоматично знаходить ці project-scoped ролі я�
 
 Перед handoff агент передає номер Issue/PR, acceptance criteria, межі файлів, команду перевірки, отриманий результат і відкриті ризики. Sol перевіряє первинні артефакти, а не лише переказ, перед злиттям результатів.
 
+## Acceptance і GitHub workflows
+
+Перед handoff або PR реалізатор запускає локальний `make check`. Це fail-closed acceptance: перший failed або flaky тест блокує delivery, а Playwright retries лишаються `0`.
+
+`Quality` у GitHub запускається лише вручну через `workflow_dispatch` і не є PR-blocker. GitHub Pages запускається напряму на кожен push у `main` та збирає exact pushed SHA. CodeQL лишається активним; його стан і всі інші налаштовані PR checks Sol перевіряє на exact PR SHA.
+
 ## Автономне злиття PR
 
 Власник не перевіряє та не схвалює PR вручну. Sol є відповідальним за merge gate і зливає PR самостійно лише після послідовного виконання всіх умов нижче.
 
 1. PR зберігає ланцюжок Issue → гілка → PR і не містить переписаної історії.
 2. Два незалежні read-only агенти виконують окремі review: один за standards, другий за spec. Вони не review-ять власну реалізацію. Sol перевіряє їхні первинні докази; кожен finding виправлено й перевірено або залишено явним blocker, який забороняє злиття.
-3. Sol перевіряє всі check runs саме цього PR. Кожен має завершитися `SUCCESS`; будь-який `FAILURE`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`, flaky результат або retry блокує злиття. Детермінований очікуваний project-scope skip у межах fail-closed quality gate можна прийняти лише за наявності його документації та за умови, що решта gate зелена.
+3. Sol перевіряє всі налаштовані PR check runs саме цього PR. Кожен має завершитися `SUCCESS`; будь-який `FAILURE`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`, flaky результат або retry блокує злиття. Ручний `Quality` не очікується як PR check.
 4. Лише після закриття review і повністю зеленої перевірки Sol позначає PR ready та створює merge commit: безпосередньо або через auto-merge, налаштований на merge commit. Auto-merge не активують до проходження цього gate.
 5. Після злиття Sol підтверджує, що `main` містить merge commit, а GitHub Pages успішно розгорнуті для цієї ревізії.

--- a/scripts/validate_quality_policy.js
+++ b/scripts/validate_quality_policy.js
@@ -8,6 +8,15 @@ const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
 const packageJson = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8")
 );
+const qualityWorkflow = readFileSync(
+  new URL("../.github/workflows/quality.yml", import.meta.url),
+  "utf8"
+);
+const pagesWorkflow = readFileSync(
+  new URL("../.github/workflows/pages.yml", import.meta.url),
+  "utf8"
+);
+const makefile = readFileSync(new URL("../Makefile", import.meta.url), "utf8");
 
 function collectPlaywrightSourceFiles(directory) {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -16,6 +25,86 @@ function collectPlaywrightSourceFiles(directory) {
     if (entry.isDirectory()) return collectPlaywrightSourceFiles(entryPath);
     return /\.[cm]?[jt]s$/u.test(entry.name) ? [entryPath] : [];
   });
+}
+
+function targetPrerequisites(target) {
+  const targetPattern = new RegExp(`^${target}:\\s*(.+)$`, "m");
+  return makefile.match(targetPattern)?.[1].trim().split(/\s+/u) ?? [];
+}
+
+function targetRecipe(target) {
+  const targetPattern = new RegExp(`^${target}:.*\\n((?:\\t.*\\n?)*)`, "m");
+  return targetPattern.exec(makefile)?.[1] ?? "";
+}
+
+function assertPrerequisites(target, requiredPrerequisites) {
+  const prerequisites = targetPrerequisites(target);
+
+  for (const prerequisite of requiredPrerequisites) {
+    if (!prerequisites.includes(prerequisite)) {
+      failures.push(
+        `Make target ${target} must run ${prerequisite} so the local quality gate remains fail-closed.`
+      );
+    }
+  }
+}
+
+function workflowTriggers(workflow) {
+  const triggerBlock = workflow.match(
+    /^on:\n([\s\S]*?)^(?:permissions|concurrency|jobs):/mu
+  )?.[1];
+
+  return [...(triggerBlock ?? "").matchAll(/^ {2}([a-z_]+):/gmu)].map(
+    ([, trigger]) => trigger
+  );
+}
+
+const qualityTriggers = workflowTriggers(qualityWorkflow);
+const automaticQualityTriggers = qualityTriggers.filter(
+  (trigger) => trigger !== "workflow_dispatch"
+);
+const pagesTriggers = workflowTriggers(pagesWorkflow);
+
+if (!qualityTriggers.includes("workflow_dispatch") || automaticQualityTriggers.length > 0) {
+  failures.push("Quality must be manual-only with workflow_dispatch as its sole trigger.");
+}
+
+if (qualityTriggers.some((trigger) => ["push", "pull_request"].includes(trigger))) {
+  failures.push("Quality must not start automatically from push or pull_request.");
+}
+
+if (!/^\s+run:\s+make check\s*$/mu.test(qualityWorkflow)) {
+  failures.push("Manual Quality must still execute the real make check gate.");
+}
+
+if (!/^on:\n\s+push:\n\s+branches:\s*\[main\]/mu.test(pagesWorkflow)) {
+  failures.push("Pages must start directly on pushes to main.");
+}
+
+if (pagesTriggers.length !== 1 || pagesTriggers[0] !== "push") {
+  failures.push("Pages must use push as its sole trigger.");
+}
+
+if (/^\s+workflow_run:/mu.test(pagesWorkflow)) {
+  failures.push("Pages must not depend on workflow_run from Quality.");
+}
+
+if (!/ref:\s*\$\{\{ github\.sha \}\}/u.test(pagesWorkflow)) {
+  failures.push("Pages must check out the exact pushed SHA.");
+}
+
+assertPrerequisites("test", ["test-unit", "test-browser"]);
+assertPrerequisites("check", [
+  "test-unit",
+  "validate-quality-policy",
+  "html",
+  "test-browser",
+]);
+
+if (!targetRecipe("test-unit").includes("$(MAKE) test-js-unit")) {
+  failures.push(
+    "Make target test-unit must run test-js-unit so JavaScript unit failures remain blocking."
+  );
 }
 
 if (playwrightConfig.retries !== 0) {
@@ -76,5 +165,5 @@ if (failures.length > 0) {
   }
   process.exitCode = 1;
 } else {
-  console.log("Quality policy is fail-closed.");
+  console.log("Local quality policy is fail-closed; GitHub Quality is manual-only.");
 }


### PR DESCRIPTION
## Summary
- make GitHub Quality manual-only while preserving real `make check` locally
- deploy Pages directly from each exact pushed SHA on `main`
- enforce the local/manual workflow policy with repository validation and documentation

## Validation
- `CI=1 make check` — 350 passed, retries 0
- independent exact-SHA Standards review — PASS
- independent exact-SHA Spec review — PASS
- CodeQL remains unchanged and active

Refs #40