### PR TITLE
fix: eliminate first-frame layout shifts

### DIFF
--- a/_includes/cinematic-stage.html
+++ b/_includes/cinematic-stage.html
@@ -58,7 +58,7 @@
     </section>
   </section>
 
-  <section class="residence-spine__stage" data-cinematic-stage hidden aria-labelledby="{{ stage_id }}-stage-title">
+  <section class="residence-spine__stage" data-cinematic-stage hidden inert aria-hidden="true" aria-labelledby="{{ stage_id }}-stage-title">
     <header class="residence-spine__stage-heading">
       <p class="section-kicker">Система резиденції</p>
       <h2 id="{{ stage_id }}-stage-title">{{ include.title }}</h2>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,9 +6,48 @@
 {% unless site.launch.indexing %}
   <meta name="robots" content="noindex, nofollow, noarchive">
 {% endunless %}
+{% if page.layout == 'landing' or page.services_catalogue %}
+<script>
+  (function () {
+    var documentRoot = document.documentElement;
+    var settlePhysicalBootstrap = function () {
+      documentRoot.removeAttribute("data-cinematic-stage-pending");
+    };
+    documentRoot.setAttribute("data-cinematic-stage-pending", "true");
+    document.addEventListener("DOMContentLoaded", settlePhysicalBootstrap, { once: true });
+    window.addEventListener("error", function (event) {
+      var target = event.target;
+      if (!target || target.tagName !== "SCRIPT") return;
+      if (target.hasAttribute("data-cinematic-physical-module")) {
+        settlePhysicalBootstrap();
+        return;
+      }
+      if (!target.hasAttribute("data-cinematic-stage-module")) return;
+      document.querySelectorAll("[data-cinematic-root]").forEach(function (root) {
+        var fallback = root.querySelector("[data-cinematic-fallback]");
+        var stage = root.querySelector("[data-cinematic-stage]");
+        root.removeAttribute("data-cinematic-enhanced");
+        root.setAttribute("data-cinematic-failed", "true");
+        if (fallback) {
+          fallback.hidden = false;
+          fallback.removeAttribute("aria-hidden");
+        }
+        if (stage) {
+          stage.hidden = true;
+          stage.setAttribute("inert", "");
+          stage.setAttribute("aria-hidden", "true");
+        }
+      });
+      documentRoot.removeAttribute("data-cinematic-stage-pending");
+    }, true);
+  }());
+</script>
+{% endif %}
+<link rel="preload" as="font" href="{{ '/assets/fonts/manrope-cyrillic.woff2' | relative_url }}" type="font/woff2" crossorigin>
+<link rel="preload" as="font" href="{{ '/assets/fonts/manrope-latin.woff2' | relative_url }}" type="font/woff2" crossorigin>
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 {% if page.url == '/' %}
-  <link rel="preload" as="image" href="{{ '/assets/images/cinematic/residence/room-evening-open-1536.webp' | relative_url }}" imagesrcset="{{ '/assets/images/cinematic/residence/room-evening-open-768.webp' | relative_url }} 768w, {{ '/assets/images/cinematic/residence/room-evening-open-1536.webp' | relative_url }} 1536w" imagesizes="(max-width: 767px) 100vw, 52vw">
+  <link rel="preload" as="image" href="{{ '/assets/images/cinematic/residence/room-evening-open-1536.webp' | relative_url }}" imagesrcset="{{ '/assets/images/cinematic/residence/room-evening-open-768.webp' | relative_url }} 768w, {{ '/assets/images/cinematic/residence/room-evening-open-1536.webp' | relative_url }} 1536w" imagesizes="(max-width: 767px) 100vw, 52vw" fetchpriority="high">
 {% endif %}
 <link rel="icon" href="{{ '/assets/brand/favicon.svg' | relative_url }}" type="image/svg+xml">
 <link rel="apple-touch-icon" href="{{ '/assets/brand/apple-touch-icon.png' | relative_url }}">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,10 +16,10 @@
     </main>
     {% include footer.html %}
     {% if page.layout == 'landing' or page.services_catalogue %}
-      <script type="module" src="{{ '/assets/js/cinematic-stage.js' | relative_url }}"></script>
+      <script type="module" src="{{ '/assets/js/cinematic-stage.js' | relative_url }}" data-cinematic-stage-module></script>
     {% endif %}
     {% if page.layout == 'landing' or page.services_catalogue or page.url == '/smart-home/' %}
-      <script type="module" src="{{ '/assets/js/physical-scene-controls.js' | relative_url }}"></script>
+      <script type="module" src="{{ '/assets/js/physical-scene-controls.js' | relative_url }}" data-cinematic-physical-module></script>
     {% endif %}
     {% if page.service_studio %}
       <script type="module" src="{{ '/assets/js/service-studio.js' | relative_url }}"></script>

--- a/_sass/_cinematic.scss
+++ b/_sass/_cinematic.scss
@@ -9,6 +9,20 @@
   display: none !important;
 }
 
+html[data-cinematic-stage-pending="true"] .residence-spine[data-cinematic-root]:not([data-cinematic-enhanced="true"]):not([data-cinematic-failed="true"]) > .residence-spine__stage[data-cinematic-stage] {
+  display: block !important;
+}
+
+html[data-cinematic-stage-pending="true"] .residence-spine[data-cinematic-root]:not([data-cinematic-enhanced="true"]):not([data-cinematic-failed="true"]) > .residence-spine__fallback[data-cinematic-fallback] {
+  display: none;
+}
+
+html[data-cinematic-stage-pending="true"] .residence-spine[data-cinematic-root]:not([data-cinematic-failed="true"]) .residence-spine__panel[data-cinematic-panel="assembled"]:not([hidden]) > .residence-spine__physical-controls[data-cinematic-physical-controls][hidden] {
+  display: grid !important;
+  pointer-events: none;
+  visibility: hidden;
+}
+
 .residence-spine__fallback {
   border-top: 1px solid var(--line-strong);
   display: grid;

--- a/assets/js/cinematic-stage.js
+++ b/assets/js/cinematic-stage.js
@@ -26,8 +26,26 @@ function readGraph(root) {
   }
 }
 
-function enhance(root) {
-  if (root.dataset.cinematicEnhanced === "true") return;
+function failClosed(root) {
+  if (!(root instanceof Element)) return;
+  const fallback = one(root, "[data-cinematic-fallback]");
+  const stage = one(root, "[data-cinematic-stage]");
+  root.removeAttribute("data-cinematic-enhanced");
+  root.setAttribute("data-cinematic-failed", "true");
+  root.removeAttribute("data-cinematic-motion-phase");
+  if (fallback) {
+    fallback.hidden = false;
+    fallback.removeAttribute("aria-hidden");
+  }
+  if (stage) {
+    stage.hidden = true;
+    stage.inert = true;
+    stage.setAttribute("aria-hidden", "true");
+  }
+  document.documentElement.removeAttribute("data-cinematic-stage-pending");
+}
+
+function enhanceValidated(root) {
 
   const source = readGraph(root);
   const fallback = one(root, "[data-cinematic-fallback]");
@@ -38,7 +56,7 @@ function enhance(root) {
   const snapshot = one(root, "[data-cinematic-outgoing-snapshot]");
   const live = one(root, "[data-cinematic-live]");
   const returnControl = one(root, "button[data-cinematic-return]");
-  if (!source || !fallback || !stage || !composition || !connectorLane || !relationshipConnector || !snapshot || !live || !returnControl) return;
+  if (!source || !fallback || !stage || !composition || !connectorLane || !relationshipConnector || !snapshot || !live || !returnControl) return false;
 
   const { graph, machine } = source;
   const directionIds = graph.directions.map((direction) => direction.id);
@@ -73,7 +91,7 @@ function enhance(root) {
     !idsMatch(relationScenes, "cinematicRelationScene", relationIds) ||
     scenes.length !== 1 + directionIds.length + relationIds.length ||
     panels.length !== 1 + directionIds.length + relationIds.length
-  ) return;
+  ) return false;
 
   const sceneByKey = new Map(scenes.map((scene) => [scene.dataset.cinematicSceneKey, scene]));
   const panelByKey = new Map([
@@ -81,7 +99,7 @@ function enhance(root) {
     ...focusPanels.map((panel) => [`focus:${panel.dataset.cinematicFocusPanel}`, panel]),
     ...reassembledPanels.map((panel) => [`relation:${panel.dataset.cinematicReassembledPanel}`, panel])
   ]);
-  if (sceneByKey.size !== scenes.length || panelByKey.size !== panels.length) return;
+  if (sceneByKey.size !== scenes.length || panelByKey.size !== panels.length) return false;
 
   const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
   let state = machine.initialState;
@@ -126,10 +144,14 @@ function enhance(root) {
   };
   const motion = createCinematicMotion({
     onPhase: (phase) => {
-      root.dataset.cinematicMotionPhase = phase;
-      synchronizePanelInertness(phase === "hold");
-      if (phase === "hold" || phase === "idle") clearTransition();
-      if (phase === "reassemble" || phase === "idle") synchronizeConnector();
+      try {
+        root.dataset.cinematicMotionPhase = phase;
+        synchronizePanelInertness(phase === "hold");
+        if (phase === "hold" || phase === "idle") clearTransition();
+        if (phase === "reassemble" || phase === "idle") synchronizeConnector();
+      } catch (_) {
+        failClosed(root);
+      }
     }
   });
 
@@ -184,28 +206,36 @@ function enhance(root) {
     if (!synchronize(true)) {
       clearTransition();
       motion.cancel();
-      return;
+      failClosed(root);
     }
   };
 
-  snapshot.addEventListener("animationend", (event) => {
+  const protect = (callback) => (...args) => {
+    try {
+      callback(...args);
+    } catch (_) {
+      failClosed(root);
+    }
+  };
+
+  snapshot.addEventListener("animationend", protect((event) => {
     if (event.animationName === "residence-spine-outgoing") clearTransition();
-  });
-  snapshot.addEventListener("animationcancel", () => {
+  }));
+  snapshot.addEventListener("animationcancel", protect(() => {
     clearTransition();
-  });
-  reducedMotion.addEventListener("change", (event) => {
+  }));
+  reducedMotion.addEventListener("change", protect((event) => {
     if (event.matches) {
       clearTransition();
       motion.cancel();
       synchronizePanelInertness(false);
     }
-  });
-  window.addEventListener("resize", () => {
-    window.requestAnimationFrame(synchronizeConnector);
-  }, { passive: true });
+  }));
+  window.addEventListener("resize", protect(() => {
+    window.requestAnimationFrame(protect(synchronizeConnector));
+  }), { passive: true });
 
-  root.addEventListener("click", (event) => {
+  root.addEventListener("click", protect((event) => {
     const control = event.target instanceof Element ? event.target.closest("button[data-cinematic-action]") : null;
     if (!(control instanceof HTMLButtonElement) || !stage.contains(control)) return;
 
@@ -216,13 +246,27 @@ function enhance(root) {
     } else if (control.dataset.cinematicAction === "return-to-system") {
       transition({ type: "return-to-system" });
     }
-  });
+  }));
 
-  if (!synchronize(false)) return;
+  if (!synchronize(false)) return false;
   root.dataset.cinematicMotionPhase = "idle";
   fallback.hidden = true;
+  fallback.setAttribute("aria-hidden", "true");
   stage.hidden = false;
+  stage.inert = false;
+  stage.removeAttribute("aria-hidden");
   root.dataset.cinematicEnhanced = "true";
+  root.removeAttribute("data-cinematic-failed");
+  return true;
+}
+
+function enhance(root) {
+  if (root.dataset.cinematicEnhanced === "true") return;
+  try {
+    if (!enhanceValidated(root)) failClosed(root);
+  } catch (_) {
+    failClosed(root);
+  }
 }
 
 document.querySelectorAll("[data-cinematic-root]").forEach(enhance);

--- a/assets/js/physical-scene-controls.js
+++ b/assets/js/physical-scene-controls.js
@@ -17,6 +17,10 @@ function responsiveCandidates(scene) {
   return `${scene.src768} 768w, ${scene.src1536} 1536w`;
 }
 
+function settleCinematicStagePending() {
+  document.documentElement.removeAttribute("data-cinematic-stage-pending");
+}
+
 function stateSignature(system, state) {
   if (system.id === "room") return `${state.lighting}:${state.window_treatment}`;
   return `${system.id}:${system.controls.map((control) => `${control.id}=${state[control.id]}`).join(":")}`;
@@ -79,13 +83,13 @@ function enhancePhysicalControls(root) {
   const snapshot = one(root, "[data-cinematic-physical-snapshot]");
   const picture = one(layer || root, "picture[data-cinematic-physical-picture]");
   const image = one(picture || root, "img[data-cinematic-physical-image]");
-  if (!physical || !stage || !live || !layer || !snapshot || !picture || !image) return;
+  if (!physical || !stage || !live || !layer || !snapshot || !picture || !image) return settleCinematicStagePending();
 
   const controlContainers = [...stage.querySelectorAll("[data-cinematic-physical-controls]")];
   const containerBySystem = new Map(controlContainers.map((container) => [text(container.dataset.cinematicPhysicalControls), container]));
   const room = physical.systemForSceneKey("assembled");
   const initialScene = room?.sceneFor(room.initialState);
-  if (!room || !initialScene || picture.dataset.cinematicPhysicalPicture !== "room" || image.getAttribute("src") !== initialScene.src768 || image.getAttribute("srcset") !== responsiveCandidates(initialScene) || image.alt !== initialScene.alt || containerBySystem.size !== physical.systems.length || physical.systems.some((system) => !containerBySystem.get(system.id) || !controlsMatch(containerBySystem.get(system.id), system))) return;
+  if (!room || !initialScene || picture.dataset.cinematicPhysicalPicture !== "room" || image.getAttribute("src") !== initialScene.src768 || image.getAttribute("srcset") !== responsiveCandidates(initialScene) || image.alt !== initialScene.alt || containerBySystem.size !== physical.systems.length || physical.systems.some((system) => !containerBySystem.get(system.id) || !controlsMatch(containerBySystem.get(system.id), system))) return settleCinematicStagePending();
 
   const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
   const states = new Map(physical.systems.map((system) => [system.id, system.initialState]));
@@ -224,6 +228,7 @@ function enhancePhysicalControls(root) {
   root.dataset.cinematicPhysicalEnhanced = "true";
   svg.setPhase("idle");
   setAvailability(root.dataset.cinematicState, root.dataset.cinematicRelation);
+  settleCinematicStagePending();
 }
 
 document.querySelectorAll("[data-cinematic-root]").forEach(enhancePhysicalControls);

--- a/tests/browser/cinematic_home_services.spec.js
+++ b/tests/browser/cinematic_home_services.spec.js
@@ -277,6 +277,18 @@ test("stair and exterior relations use the same physical layer to swap their own
 });
 
 test("physical controls fail closed for malformed state data", async ({ page }) => {
+  await page.route("**/assets/js/physical-scene-controls.js", (route) => route.fulfill({
+    contentType: "application/javascript",
+    body: "throw new Error('physical runtime failure');"
+  }));
+  await page.goto("/");
+  let rendered = await stageFor(page);
+  await expect(page.locator("html")).not.toHaveAttribute("data-cinematic-stage-pending", "true");
+  await expect(rendered.root).not.toHaveAttribute("data-cinematic-physical-enhanced", "true");
+  await expect(rendered.stage.locator("[data-cinematic-physical-controls]:visible")).toHaveCount(0);
+  await expect(rendered.stage.locator("[data-cinematic-physical-layer]")).toBeHidden();
+
+  await page.unroute("**/assets/js/physical-scene-controls.js");
   await page.addInitScript(() => {
     const originalParse = JSON.parse;
     JSON.parse = function physicalSceneParse(value, ...rest) {
@@ -285,9 +297,9 @@ test("physical controls fail closed for malformed state data", async ({ page }) 
     };
   });
   await page.goto("/");
-  const { stage } = await stageFor(page);
-  await expect(stage.locator("[data-cinematic-physical-controls]:visible")).toHaveCount(0);
-  await expect(stage.locator("[data-cinematic-physical-layer]")).toBeHidden();
+  rendered = await stageFor(page);
+  await expect(rendered.stage.locator("[data-cinematic-physical-controls]:visible")).toHaveCount(0);
+  await expect(rendered.stage.locator("[data-cinematic-physical-layer]")).toBeHidden();
 });
 
 test("a unique but wrong physical control ID fails closed before controls become interactive", async ({ page }) => {

--- a/tests/browser/final_acceptance.spec.js
+++ b/tests/browser/final_acceptance.spec.js
@@ -187,6 +187,13 @@ const dynamicFallbacks = Object.freeze([
   }))
 ]);
 const geometryWidths = Object.freeze([375, 768, 900, 1024, 1440, 1980]);
+const cinematicFirstFrameViewports = Object.freeze([
+  { width: 320, height: 700 },
+  { width: 375, height: 812 },
+  { width: 768, height: 1024 },
+  { width: 1440, height: 1000 },
+  { width: 1980, height: 1200 }
+]);
 const compositionGeometryContracts = Object.freeze([
   ...["/", "/services/"].map((route) => ({
     family: "residence",
@@ -1163,12 +1170,82 @@ async function transitJourney(page, route) {
 
 test("all twenty-four public routes stay semantic, linked, fluid, and error-free in the full JavaScript matrix", async ({ browser }) => {
   expect(publicRoutes).toHaveLength(24);
-  const context = await browser.newContext({ baseURL, locale: "uk-UA" });
-  const page = await context.newPage();
+  let context = await browser.newContext({ baseURL, locale: "uk-UA" });
+  let page = await context.newPage();
   const checkedInternalRoutes = new Set();
   const matrix = [];
 
+  await page.addInitScript(() => {
+    window.__cinematicStageCls = 0;
+    new PerformanceObserver((entries) => {
+      for (const entry of entries.getEntries()) {
+        if (!entry.hadRecentInput) window.__cinematicStageCls += entry.value;
+      }
+    }).observe({ type: "layout-shift", buffered: true });
+  });
+
   try {
+    const delayCinematicStage = async (route) => {
+      await page.waitForTimeout(900);
+      await route.continue();
+    };
+    await page.route("**/assets/js/cinematic-stage.js", delayCinematicStage);
+    for (const viewport of cinematicFirstFrameViewports) {
+      await page.setViewportSize(viewport);
+      for (const route of ["/", "/services/"]) {
+        const response = await page.goto(route, { waitUntil: "commit" });
+        expect(response?.ok(), route + " must begin a successful first-frame document").toBeTruthy();
+        const root = page.locator("[data-cinematic-root]");
+        const stage = root.locator("[data-cinematic-stage]");
+        const fallback = root.locator("[data-cinematic-fallback]");
+        await expect(root).not.toHaveAttribute("data-cinematic-enhanced", "true");
+        await expect(root).not.toHaveAttribute("data-cinematic-failed", "true");
+        await expect(stage).toBeVisible();
+        await expect(stage).toHaveAttribute("inert", "");
+        await expect(stage).toHaveAttribute("aria-hidden", "true");
+        await expect(fallback).toBeHidden();
+        await expect(stage.locator("[data-cinematic-panel='assembled'] [data-cinematic-physical-controls='room']")).toBeHidden();
+        const before = await page.evaluate(() => {
+          const bounds = (element) => {
+            const rect = element.getBoundingClientRect();
+            return { left: rect.left, top: rect.top, width: rect.width, height: rect.height };
+          };
+          return {
+            root: bounds(document.querySelector("[data-cinematic-root]")),
+            footer: bounds(document.querySelector("footer"))
+          };
+        });
+
+        await expect(root).toHaveAttribute("data-cinematic-enhanced", "true");
+        await page.evaluate(() => document.fonts.ready);
+        await page.evaluate(() => new Promise((resolveFrame) => requestAnimationFrame(() => requestAnimationFrame(resolveFrame))));
+        await expect(stage).not.toHaveAttribute("inert");
+        await expect(stage).not.toHaveAttribute("aria-hidden");
+        await expect(stage.getByRole("button").first()).toBeEnabled();
+        await expect(fallback).toBeHidden();
+        const after = await page.evaluate(() => {
+          const bounds = (element) => {
+            const rect = element.getBoundingClientRect();
+            return { left: rect.left, top: rect.top, width: rect.width, height: rect.height };
+          };
+          return {
+            root: bounds(document.querySelector("[data-cinematic-root]")),
+            footer: bounds(document.querySelector("footer")),
+            cls: window.__cinematicStageCls
+          };
+        });
+        for (const element of ["root", "footer"]) {
+          for (const dimension of ["left", "top", "width", "height"]) {
+            expect(Math.abs(after[element][dimension] - before[element][dimension]), `${route} cinematic ${element} ${dimension} must remain stable at ${viewport.width}px`).toBeLessThanOrEqual(1);
+          }
+        }
+        expect(after.cls, route + " cinematic first-frame CLS must stay below 0.001 at " + viewport.width + "px").toBeLessThanOrEqual(0.001);
+      }
+    }
+    await context.close();
+    context = await browser.newContext({ baseURL, locale: "uk-UA" });
+    page = await context.newPage();
+
     for (const width of acceptanceWidths) {
       await page.setViewportSize(viewportFor(width));
       for (const route of publicRoutes) {

--- a/tests/unit/cinematic_contract_test.rb
+++ b/tests/unit/cinematic_contract_test.rb
@@ -264,6 +264,8 @@ class CinematicContractTest < Minitest::Test
 
   def test_residence_physical_picture_exposes_one_preload_safe_responsive_candidate_list
     template = File.read(File.join(project_root, "_includes", "cinematic-stage.html"))
+    head = File.read(File.join(project_root, "_includes", "head.html"))
+    layout = File.read(File.join(project_root, "_layouts", "default.html"))
     physical_layer = template[/<div class="residence-spine__physical-layer"[^>]*data-cinematic-physical-layer[^>]*>/]
 
     refute_nil physical_layer
@@ -271,7 +273,12 @@ class CinematicContractTest < Minitest::Test
     refute_includes template, '<source data-cinematic-physical-source'
     refute_includes template, '<source media="(max-width: 767px)" srcset="{{ \'/assets/images/smart-home/\' | append: relation.scene_family | append: \'-768.webp\' | relative_url }}"'
     assert_includes template, '<img data-cinematic-physical-image src="{{ initial_physical_scene.src_768 | relative_url }}" srcset="{{ initial_physical_scene.src_768 | relative_url }} 768w, {{ initial_physical_scene.src_1536 | relative_url }} 1536w"'
-    assert_includes template, 'sizes="(max-width: 767px) 100vw, 52vw"'
+    assert template.include?('sizes="(max-width: 767px) 100vw, 52vw"') &&
+      head.match?(/<script>[\s\S]*?data-cinematic-stage-pending[\s\S]*?addEventListener\("error"[\s\S]*?data-cinematic-stage-module[\s\S]*?<\/script>[\s\S]*?<link rel="preload" as="font" href="\{\{ '\/assets\/fonts\/manrope-cyrillic\.woff2' \| relative_url \}\}" type="font\/woff2" crossorigin>[\s\S]*?<link rel="preload" as="font" href="\{\{ '\/assets\/fonts\/manrope-latin\.woff2' \| relative_url \}\}" type="font\/woff2" crossorigin>[\s\S]*?<link rel="stylesheet"/m) &&
+      head.match?(/rel="preload" as="image" href="\{\{ '\/assets\/images\/cinematic\/residence\/room-evening-open-1536\.webp' \| relative_url \}\}"[^>]*fetchpriority="high"/) &&
+      layout.match?(/<script type="module" src="\{\{ '\/assets\/js\/cinematic-stage\.js' \| relative_url \}\}" data-cinematic-stage-module><\/script>/) &&
+      layout.match?(/<script type="module" src="\{\{ '\/assets\/js\/physical-scene-controls\.js' \| relative_url \}\}" data-cinematic-physical-module><\/script>/), "cinematic first-frame bootstrap, font preloads, and LCP priority must retain their source contract"
+    assert template.include?('data-cinematic-stage hidden inert aria-hidden="true"'), "the first-paint stage must remain inaccessible until enhancement succeeds"
   end
 
   def test_physical_scene_adapter_updates_one_responsive_candidate_list


### PR DESCRIPTION
## Що змінено

- показуємо валідовану cinematic stage до першого paint без SSR-to-stage стрибка;
- резервуємо геометрію physical controls без відкриття неактивних елементів;
- fail-closed обробляє resource, validation і runtime failures;
- preload обох локальних Manrope subsets прибирає font-swap CLS;
- LCP image preload тепер має high fetch priority;
- responsive CLS contract охоплює 320, 375, 768, 1440 і 1980 px.

## Acceptance

- canonical local gate: PASS — 695/695 Playwright, retries 0, workers 1;
- Node: 72/72;
- Ruby/contract suites: PASS;
- Jekyll production build + HTML-Proofer + content/assets validators: PASS;
- Lighthouse 13.4.1 local mobile/desktop: CLS 0, accessibility 100, best practices 100;
- independent spec review: PASS;
- independent standards/fail-closed re-review: PASS, no blocker/high/medium findings.

Production PageSpeed will be repeated after Pages deploy. Public indexing remains unchanged in this PR because it is a separate launch decision; the current noindex intentionally limits the SEO category.

Closes #63