### PR TITLE
fix(#63): stabilize the mobile initial paint

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="color-scheme" content="dark">
 <meta name="theme-color" content="#040201">
+<style data-initial-page-shell>html,body{background:#040201}</style>
 {% seo %}
 {% unless site.launch.indexing %}
   <meta name="robots" content="noindex, nofollow, noarchive">

--- a/scripts/run_ruby_test.rb
+++ b/scripts/run_ruby_test.rb
@@ -13,7 +13,7 @@ EXPECTED_RESULTS = {
   "cinematic_route_transition_contract_test.rb" => [1, 2],
   "production_assets_contract_test.rb" => [6, 94],
   "public_claims_contract_test.rb" => [14, 382],
-  "landing_inline_css_contract_test.rb" => [4, 38]
+  "landing_inline_css_contract_test.rb" => [5, 46]
 }.freeze
 
 require "open3"

--- a/scripts/validate_quality_policy.js
+++ b/scripts/validate_quality_policy.js
@@ -18,7 +18,7 @@ const AUDITED_PLAYWRIGHT_REPORTER_SHA256 =
   "0c1388452ee052ec6e504e811cac34c3543f419a6aef3e0de35d33a713d6ef32";
 const AUDITED_LOCAL_ENTRYPOINT_SHA256 = new Map([
   ["run_node_tests.js", "5eeda7311ca7dd62e4f20d8b5070fb49e4d8d6bb342703a75e0865cf02027e35"],
-  ["run_ruby_test.rb", "fee57d80fc9769bbcc4f6a3a35fa48b751c88a34737ab6b1c5919ceff5c31fe7"],
+  ["run_ruby_test.rb", "a1df6568b4bbbdf987a03b21a9ddaa1e9d288a3587f0286a0c40f1c7588d8491"],
   ["verify_agent_skills.rb", "37095cc3690e974f688b79d427ceadc4f69554acac5d666514c37affaad440fc"],
   ["validate_integrations.rb", "4d61fda2e1a474a0f3aaef69c1f033f7d018e87374a286fc25fc6881eaf4d531"],
   ["validate_production_assets.rb", "e89bfee3f0cd2d53776a79309703067086815ed7f233ce36572415e72e043686"],

--- a/tests/unit/landing_inline_css_contract_test.rb
+++ b/tests/unit/landing_inline_css_contract_test.rb
@@ -57,6 +57,20 @@ class LandingInlineCssContractTest < Minitest::Test
     end
   end
 
+  def test_initial_dark_shell_precedes_the_full_landing_stylesheet
+    build_site do |destination|
+      homepage_html = File.read(File.join(destination, "index.html"))
+      initial_shell = '<style data-initial-page-shell>html,body{background:#040201}</style>'
+
+      assert_includes homepage_html, initial_shell
+      assert_operator homepage_html.index(initial_shell), :<,
+                      homepage_html.index('<style data-landing-inline-css>')
+
+      about_html = File.read(File.join(destination, "about", "index.html"))
+      assert_includes about_html, initial_shell
+    end
+  end
+
   def test_generator_rejects_a_stale_generated_artifact
     original = File.binread(GENERATED_CSS)
     File.binwrite(GENERATED_CSS, "#{original} ")


### PR DESCRIPTION
## Що змінено

- додає 69-байтовий темний initial canvas до SEO/bootstrap і повного landing CSS;
- прибирає білий стартовий кадр, який домінував у mobile Speed Index;
- додає production Jekyll contract на exact shell, порядок у `<head>` і non-landing route;
- синхронізує fail-closed Ruby inventory та audited launcher digest.

## Доказ причини

Fresh production PSI після #65: mobile P98, SI 3.7 s; filmstrip білий до 2.25 s і final-like на 2.625 s. Старий eager/high-image звіт мав той самий таймінг, тому image priority виключено як root cause. Dark canvas `#040201` на 89.4% ближчий до фінального mobile viewport за білий. Потокова браузерна перевірка підтвердила `rgb(4, 2, 1)` ще до отримання `<body>`.

## Acceptance

- `node scripts/validate_quality_policy.js && make -f Makefile check`: PASS;
- Ruby: 136 runs / 2,752 assertions, 0 fail/error/skip;
- Node: 73/73, 0 fail/skip/todo;
- Chromium: 695/695, workers=1, retries=0, 0 fail/skip;
- Standards review: PASS;
- Spec review: PASS;
- зібраний HTML без нового shell побітово ідентичний production до зміни.

Production PageSpeed mobile/desktop буде повторено після exact-SHA Pages deployment. SEO 69 не маскується: public indexing потребує окремого launch-рішення власника.

Refs #63