### PR TITLE
fix(#63): prioritize the mobile opening scene

### DIFF
--- a/_includes/cinematic-stage.html
+++ b/_includes/cinematic-stage.html
@@ -103,7 +103,7 @@
             data-cinematic-scene-image="url('{{ initial_physical_scene.src_1536 | relative_url }}')"
           >
             <picture>
-              <img src="{{ initial_physical_scene.src_768 | relative_url }}" srcset="{{ initial_physical_scene.src_768 | relative_url }} 768w, {{ initial_physical_scene.src_1536 | relative_url }} 1536w" width="768" height="512" sizes="(max-width: 767px) 100vw, 52vw" alt="{{ initial_physical_scene.alt }}" loading="lazy"{% if stage_variant == 'home' %} fetchpriority="low"{% endif %}>
+              <img src="{{ initial_physical_scene.src_768 | relative_url }}" srcset="{{ initial_physical_scene.src_768 | relative_url }} 768w, {{ initial_physical_scene.src_1536 | relative_url }} 1536w" width="768" height="512" sizes="(max-width: 767px) 100vw, 52vw" alt="{{ initial_physical_scene.alt }}" loading="{% if stage_variant == 'home' %}eager{% else %}lazy{% endif %}"{% if stage_variant == 'home' %} fetchpriority="high"{% endif %}>
             </picture>
           </figure>
 

--- a/scripts/run_ruby_test.rb
+++ b/scripts/run_ruby_test.rb
@@ -13,7 +13,7 @@ EXPECTED_RESULTS = {
   "cinematic_route_transition_contract_test.rb" => [1, 2],
   "production_assets_contract_test.rb" => [6, 94],
   "public_claims_contract_test.rb" => [14, 382],
-  "landing_inline_css_contract_test.rb" => [5, 46]
+  "landing_inline_css_contract_test.rb" => [5, 48]
 }.freeze
 
 require "open3"

--- a/scripts/validate_quality_policy.js
+++ b/scripts/validate_quality_policy.js
@@ -18,7 +18,7 @@ const AUDITED_PLAYWRIGHT_REPORTER_SHA256 =
   "0c1388452ee052ec6e504e811cac34c3543f419a6aef3e0de35d33a713d6ef32";
 const AUDITED_LOCAL_ENTRYPOINT_SHA256 = new Map([
   ["run_node_tests.js", "5eeda7311ca7dd62e4f20d8b5070fb49e4d8d6bb342703a75e0865cf02027e35"],
-  ["run_ruby_test.rb", "a1df6568b4bbbdf987a03b21a9ddaa1e9d288a3587f0286a0c40f1c7588d8491"],
+  ["run_ruby_test.rb", "aacfb649825b8f515435c24d95fd63f0c6b5cfe6804ab4e088328a2d73331f5e"],
   ["verify_agent_skills.rb", "37095cc3690e974f688b79d427ceadc4f69554acac5d666514c37affaad440fc"],
   ["validate_integrations.rb", "4d61fda2e1a474a0f3aaef69c1f033f7d018e87374a286fc25fc6881eaf4d531"],
   ["validate_production_assets.rb", "e89bfee3f0cd2d53776a79309703067086815ed7f233ce36572415e72e043686"],

--- a/tests/unit/landing_inline_css_contract_test.rb
+++ b/tests/unit/landing_inline_css_contract_test.rb
@@ -93,7 +93,7 @@ class LandingInlineCssContractTest < Minitest::Test
     end
   end
 
-  def test_homepage_defers_the_image_on_mobile_while_preserving_desktop_preload
+  def test_homepage_prioritizes_the_initial_scene_while_preserving_desktop_preload
     build_site do |destination|
       homepage = document(destination, "index.html")
       preload = homepage.at_css('head > link[rel="preload"][as="image"]')
@@ -101,8 +101,8 @@ class LandingInlineCssContractTest < Minitest::Test
 
       assert_equal "(min-width: 768px)", preload["media"]
       assert_equal "high", preload["fetchpriority"]
-      assert_equal "lazy", assembled_image["loading"]
-      assert_equal "low", assembled_image["fetchpriority"]
+      assert_equal "eager", assembled_image["loading"]
+      assert_equal "high", assembled_image["fetchpriority"]
     end
   end
 end

--- a/tests/unit/landing_inline_css_contract_test.rb
+++ b/tests/unit/landing_inline_css_contract_test.rb
@@ -103,6 +103,11 @@ class LandingInlineCssContractTest < Minitest::Test
       assert_equal "high", preload["fetchpriority"]
       assert_equal "eager", assembled_image["loading"]
       assert_equal "high", assembled_image["fetchpriority"]
+
+      services = document(destination, "services/index.html")
+      services_image = services.at_css('[data-cinematic-scene-state="assembled"] picture > img')
+      assert_equal "lazy", services_image["loading"]
+      assert_nil services_image["fetchpriority"]
     end
   end
 end


### PR DESCRIPTION
## Що змінено

- початкова сцена лише на homepage тепер `loading="eager"` + `fetchpriority="high"`;
- `/services/` та всі інші cinematic-сцени залишаються lazy;
- production Jekyll contract фіксує обидві межі scope.

## Доказ причини

На однаковому deploy `2ed3080` PageSpeed дав mobile 100, коли lazy request стартував на 333 ms, і mobile 98, коли браузер відклав його до 1301 ms. FCP/SI зсунулися разом із цим єдиним 33 KB request. Ранній dark shell уже прибрав білий canvas; eager/high прибирає останню browser-heuristic варіативність.

## Acceptance

- exact full local gate: PASS;
- Ruby 136/2,754, 0 fail/error/skip;
- Node 73/73, 0 fail/skip;
- Chromium 695/695, workers=1, retries=0, 0 fail/skip;
- Standards re-review: PASS після додавання `/services/` negative contract;
- Spec re-review: PASS.

Після exact-SHA Pages deploy буде виконано щонайменше три production PSI прогони. SEO 69 лишається окремим noindex launch-рішенням.

Refs #63